### PR TITLE
Fix price selection in createOrder

### DIFF
--- a/backend/controllers/ordersController.js
+++ b/backend/controllers/ordersController.js
@@ -2,7 +2,7 @@ const knex = require('../db/knex');
 
 exports.createOrder = async (req, res) => {
   // Extract data from the request body.
-  // The 'items' array is crucial and should contain objects with { productId, quantity, unitPrice, totalPrice, productName }
+  // The 'items' array is crucial and should contain objects with { productId, quantity, price, totalPrice, productName }
   const { userId, tableId, orderNumber, order_number, status, items } = req.body;
   const orderNum = orderNumber || order_number;
   const key = req.idempotencyKey;
@@ -40,7 +40,7 @@ exports.createOrder = async (req, res) => {
         order_id: order.id,
         product_id: item.productId,
         quantity: item.quantity,
-        price: item.unitPrice,
+        price: item.price ?? item.unitPrice,
         total_price: item.totalPrice,
         product_name: item.productName,
       }));


### PR DESCRIPTION
## Summary
- handle unitPrice fallback when creating order items
- note the `price` field in createOrder docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f672360d4832d80649029f1e5c62c